### PR TITLE
Control log level of Container logger inside of CloudWatch logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ ManageIQ::Loggers::Base
 ManageIQ::Loggers::Container
 ManageIQ::Loggers::CloudWatch
 ManageIQ::Loggers::Journald
+Insights::Loggers::Container
 Insights::Loggers::StdErrorLogger
 TopologicalInventory::Providers::Common::Logger
 ```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Standard error logger produces formatted output:
  "pid":11561, # process id
  "tid":"3fd1d4c2ffd4", # thread id
  "service": "progname",
- "level":"warning", #info, warning, error, debug
+ "level":"warning", # info(default), warning, error, debug
  "message":"test",
  "request_id": "REQ_ID", # Thread.current[:request_id]
  "tags":["MyApp"],

--- a/lib/insights/loggers/cloud_watch.rb
+++ b/lib/insights/loggers/cloud_watch.rb
@@ -1,0 +1,33 @@
+# inspired by https://github.com/ManageIQ/manageiq-loggers/blob/master/lib/manageiq/loggers/cloud_watch.rb
+require 'active_support/core_ext/string'
+require 'active_support/logger'
+
+module Insights
+  module Loggers
+    class CloudWatch < ManageIQ::Loggers::Base
+      NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace".freeze
+
+      def self.new(*args)
+        access_key_id     = ENV["CW_AWS_ACCESS_KEY_ID"].presence
+        secret_access_key = ENV["CW_AWS_SECRET_ACCESS_KEY"].presence
+        log_group_name    = ENV["CLOUD_WATCH_LOG_GROUP"].presence
+        log_stream_name   = ENV["HOSTNAME"].presence
+        container_logger = Insights::Loggers::Container.new
+
+        return container_logger unless access_key_id && secret_access_key && log_group_name && log_stream_name
+
+        require 'cloudwatchlogger'
+
+        creds = {:access_key_id => access_key_id, :secret_access_key => secret_access_key}
+        cloud_watch_logdev = CloudWatchLogger::Client.new(creds, log_group_name, log_stream_name)
+        super(cloud_watch_logdev).tap { |logger| logger.extend(ActiveSupport::Logger.broadcast(container_logger)) }
+      end
+
+      def initialize(logdev, *args)
+        super
+        self.formatter = ManageIQ::Loggers::Container::Formatter.new
+        self.level = ENV['LOG_LEVEL'] if ENV['LOG_LEVEL']
+      end
+    end
+  end
+end

--- a/lib/insights/loggers/container.rb
+++ b/lib/insights/loggers/container.rb
@@ -4,6 +4,11 @@ require 'active_support/logger'
 module Insights
   module Loggers
     class Container < ManageIQ::Loggers::Container
+      def initialize(logdev = STDOUT, *args)
+        super
+        self.level = ENV['CONTAINER_LOG_LEVEL'] || ENV['LOG_LEVEL'] || DEBUG
+      end
+
       def level=(new_level)
         # overwrite method ManageIQ::Loggers::Container#level=
         method(__method__).super_method.super_method.call(new_level)

--- a/lib/insights/loggers/container.rb
+++ b/lib/insights/loggers/container.rb
@@ -1,0 +1,13 @@
+require 'active_support/core_ext/string'
+require 'active_support/logger'
+
+module Insights
+  module Loggers
+    class Container < ManageIQ::Loggers::Container
+      def level=(new_level)
+        # overwrite method ManageIQ::Loggers::Container#level=
+        method(__method__).super_method.super_method.call(new_level)
+      end
+    end
+  end
+end

--- a/lib/insights/loggers/factory.rb
+++ b/lib/insights/loggers/factory.rb
@@ -63,6 +63,11 @@ module Insights
 
             require EXTENDED_LIBRARY_FROM_MODULE[args[:extend_module]]
           end
+        when "Insights::Loggers::CloudWatch"
+          require "manageiq/loggers/base"
+          require "manageiq/loggers/container"
+          require "insights/loggers/container"
+          require "insights/loggers/cloud_watch"
         when "TopologicalInventory::Providers::Common::Logger"
           require "topological_inventory/providers/common/logging"
         when "Insights::Loggers::Container"

--- a/lib/insights/loggers/factory.rb
+++ b/lib/insights/loggers/factory.rb
@@ -64,6 +64,10 @@ module Insights
           end
         when "TopologicalInventory::Providers::Common::Logger"
           require "topological_inventory/providers/common/logging"
+        when "Insights::Loggers::Container"
+          require "manageiq/loggers/base"
+          require "manageiq/loggers/container"
+          require "insights/loggers/container"
         else
           raise ArgumentError, "Can't load libraries for #{logger_class}."
         end

--- a/lib/insights/loggers/factory.rb
+++ b/lib/insights/loggers/factory.rb
@@ -55,6 +55,7 @@ module Insights
         when "Insights::Loggers::StdErrorLogger"
           require "manageiq/loggers/base"
           require "manageiq/loggers/container"
+          require "insights/loggers/container"
           require "insights/loggers/std_error_logger"
           if args && args[:extend_module]
             library_path = EXTENDED_LIBRARY_FROM_MODULE[args[:extend_module]]

--- a/lib/insights/loggers/std_error_logger.rb
+++ b/lib/insights/loggers/std_error_logger.rb
@@ -1,10 +1,11 @@
 module Insights
   module Loggers
-    class StdErrorLogger < ManageIQ::Loggers::Container
+    class StdErrorLogger < Container
       def initialize(*args)
         super
         self.reopen(STDERR)
         self.formatter = Formatter.new
+        self.level = INFO
       end
 
       def app_name_for_formatter(app_name)

--- a/spec/insights/factory_spec.rb
+++ b/spec/insights/factory_spec.rb
@@ -17,6 +17,7 @@ describe Insights::Loggers::Factory do
       ManageIQ::Loggers::CloudWatch
       ManageIQ::Loggers::Journald
       Insights::Loggers::StdErrorLogger
+      Insights::Loggers::CloudWatch
       Insights::Loggers::Container
       TopologicalInventory::Providers::Common::Logger
     ].freeze
@@ -26,12 +27,24 @@ describe Insights::Loggers::Factory do
         arguments = {}
         arguments[:log_path] = "test" if logger_klass == "ManageIQ::Loggers::Base"
 
-      if logger_klass == "ManageIQ::Loggers::Journald" && RbConfig::CONFIG['host_os'] !~ /linux/i
+        if logger_klass == "ManageIQ::Loggers::Journald" && RbConfig::CONFIG['host_os'] !~ /linux/i
           expect do
             described_class.create_logger(logger_klass, arguments)
           end.to raise_error(RuntimeError)
         else
+          if logger_klass == "Insights::Loggers::CloudWatch"
+            ENV["CONTAINER_LOG_LEVEL"] = "info"
+            ENV["LOG_LEVEL"] = "info"
+          end
+
           logger = described_class.create_logger(logger_klass, arguments)
+
+          if logger_klass == "Insights::Loggers::CloudWatch"
+            expect { logger.debug("test") }.not_to output.to_stdout_from_any_process
+            ENV["CONTAINER_LOG_LEVEL"] = nil
+            ENV["LOG_LEVEL"] = nil
+          end
+
           expect(logger).to be_a(logger_klass.safe_constantize)
         end
       end

--- a/spec/insights/factory_spec.rb
+++ b/spec/insights/factory_spec.rb
@@ -17,6 +17,7 @@ describe Insights::Loggers::Factory do
       ManageIQ::Loggers::CloudWatch
       ManageIQ::Loggers::Journald
       Insights::Loggers::StdErrorLogger
+      Insights::Loggers::Container
       TopologicalInventory::Providers::Common::Logger
     ].freeze
 

--- a/spec/insights/std_error_logger_spec.rb
+++ b/spec/insights/std_error_logger_spec.rb
@@ -1,5 +1,6 @@
 require 'manageiq/loggers/base'
 require 'manageiq/loggers/container'
+require 'insights/loggers/container'
 require 'insights/loggers/std_error_logger'
 require 'timecop'
 


### PR DESCRIPTION
- Add `Insights::Loggers::Container` - we can have own container  logger where we can set log level by `ENV['CONTAINER_LOG_LEVEL']` (default is DEBUG level)
- Use `Insights::Loggers::Container` in `Insights::Loggers::StdErrorLogger` - we can set log level for `StdErrorLogger` in case it will be need in future 
- Add `Insights::Loggers::CloudWatch` - we can set log level in container logger inside by `ENV['LOG_LEVEL']` (default is INFO level)

if `ENV['CONTAINER_LOG_LEVEL']` is not set, then  `ENV['LOG_LEVEL']` is used for container logging.
