### PR TITLE
Pin Miq Loggers gem to 0.4.x

### DIFF
--- a/insights-loggers-ruby.gemspec
+++ b/insights-loggers-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", "~> 5.2", ">= 5.2.4.3"
 
-  spec.add_runtime_dependency "manageiq-loggers", "~> 0.4", ">= 0.4.2"
+  spec.add_runtime_dependency "manageiq-loggers", "~> 0.4.0", ">= 0.4.2"
 
   spec.add_runtime_dependency "cloudwatchlogger", "~> 0.2.1"
 

--- a/spec/insights/std_error_logger_spec.rb
+++ b/spec/insights/std_error_logger_spec.rb
@@ -32,13 +32,21 @@ describe Insights::Loggers::StdErrorLogger do
     let(:request_id) { "123" }
 
     context "in :request_id" do
-      before { Thread.current[:request_id] = request_id }
-      after  { Thread.current[:request_id] = nil }
+      let(:request) { double(:request_id => request_id) }
+
+      before do
+        Thread.current[:current_request] = request
+      end
+
+      after do
+        Thread.current[:current_request] = nil
+      end
 
       it "logs a message" do
         time_formatted = time.strftime("%Y-%m-%dT%H:%M:%S.%6N ".freeze)
         logger = described_class.new
-        expected_output  = JSON.generate(expected_hash(time_formatted, log_message, request_id)) << "\n"
+
+        expected_output = JSON.generate(expected_hash(time_formatted, log_message, request_id)) << "\n"
         expect { logger.info(log_message) }.to output(expected_output).to_stderr_from_any_process
       end
     end


### PR DESCRIPTION
Reason: 0.7.0 breaks insights-api-common container 

Fixes CI failure:
https://github.com/RedHatInsights/sources-satellite/pull/14